### PR TITLE
add a tifffile specific reader and add full RGB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Python Version](https://img.shields.io/pypi/pyversions/napari-imsmicrolink.svg?color=green)](https://python.org)
 [![tests](https://github.com/nhpatterson/napari-imsmicrolink/workflows/tests/badge.svg)](https://github.com/nhpatterson/napari-imsmicrolink/actions)
 
-[napari] plugin to perform MALDI IMS - microscopy registration using laser ablation marks as described in [Anal. Chem. 2018, 90, 21, 12395–12403](https://pubs.acs.org/doi/abs/10.1021/acs.analchem.8b02884). This plugin is a work-in-progress but is mostly functional. It does not yet support RGB brightfield images for registration.
+[napari] plugin to perform MALDI IMS - microscopy registration using laser ablation marks as described in [Anal. Chem. 2018, 90, 21, 12395–12403](https://pubs.acs.org/doi/abs/10.1021/acs.analchem.8b02884). This plugin is a work-in-progress but is mostly functional.
 
 __N.B.__ This tool is __NOT__ a general purpose registration framework to find transforms between IMS (MALDI or otherwise)
 and microscopy. It is built to align MALDI IMS pixels to their corresponding laser ablation marks as captured by microscopy AFTER the IMS experiment. 

--- a/napari_imsmicrolink/_dock_widget.py
+++ b/napari_imsmicrolink/_dock_widget.py
@@ -107,6 +107,7 @@ class IMSMicroLink(QWidget):
         )
 
         # transform control
+        self._tform_c.tform_ctl.reset_transform.clicked.connect(self.reset_transform)
         self._tform_c.tform_ctl.run_transform.clicked.connect(self.run_transformation)
         self._tform_c.rot_ctl.rot_mi_90cw.clicked.connect(
             lambda: self._rotate_modality("microscopy", -90)
@@ -388,10 +389,11 @@ class IMSMicroLink(QWidget):
 
         if self.microscopy_image.is_rgb:
             cnames = self.microscopy_image.cnames[0]
-        elif not c_axis:
+        elif c_axis is None:
             cnames = self.microscopy_image.cnames[0]
         else:
             cnames = self.microscopy_image.cnames
+
 
         file_path = self.microscopy_image.image_filepath
         fp_name = Path(file_path).name
@@ -890,7 +892,6 @@ class IMSMicroLink(QWidget):
             for micro_im in self.micro_image_names:
                 self.viewer.layers[micro_im].affine = microscopy_transform
             self.viewer.layers["Microscopy Fiducials"].affine = microscopy_transform
-            self._current_microscopy_transform = microscopy_transform
             self._micro_rot += angle
 
         if modality == "ims" and self.ims_pixel_map:
@@ -915,6 +916,12 @@ class IMSMicroLink(QWidget):
             self._update_output_size()
 
         return
+
+    def reset_transform(self) -> None:
+        for micro_im in self.micro_image_names:
+            self.viewer.layers[micro_im].affine = np.eye(3)
+        self.viewer.layers["Microscopy Fiducials"].affine = np.eye(3)
+        self._micro_rot = 0
 
     def _ims_res_timing(self) -> None:
         """Wait until there are no changes for 0.5 second before making changes."""

--- a/napari_imsmicrolink/data/__init__.py
+++ b/napari_imsmicrolink/data/__init__.py
@@ -2,4 +2,5 @@ from .ims_pixel_map import PixelMapIMS
 from .image_transform import ImageTransform
 from .microscopy_reader import MicroRegImage
 from .czi_reader import CziRegImage
+from .tifffile_reader import TiffFileRegImage, TIFFFILE_EXTS
 from .microscopy_writer import OmeTiffWriter

--- a/napari_imsmicrolink/data/microscopy_writer.py
+++ b/napari_imsmicrolink/data/microscopy_writer.py
@@ -46,6 +46,10 @@ class OmeTiffWriter:
         self.microscopy_image: Union[MicroRegImage, CziRegImage] = microscopy_image
         self.image_series_idx: int = self.microscopy_image.base_layer_idx
         self.dask_im: da.Array = self.microscopy_image.pyr_levels_dask[1]
+        if len(self.dask_im.shape) < 3:
+            self.dask_im = self.dask_im.reshape(
+                (1, self.dask_im.shape[0], self.dask_im.shape[1])
+            )
         self.n_ch: int = self.dask_im.shape[0]
         self.image_name: str = image_name
         self.image_transform: sitk.AffineTransform = image_transform
@@ -137,6 +141,8 @@ class OmeTiffWriter:
         subifds = n_pyr_levels - 1
 
         compression = "jpeg" if self.microscopy_image.is_rgb else "deflate"
+        if self.dask_im.shape == 1:
+            self.dask_im
         with TiffWriter(output_file_name, bigtiff=True) as tif:
             rgb_stores = []
             for channel_idx in range(self.microscopy_image.n_ch):

--- a/napari_imsmicrolink/data/tifffile_reader.py
+++ b/napari_imsmicrolink/data/tifffile_reader.py
@@ -37,6 +37,9 @@ class TiffFileRegImage:
         d_image = self.get_dask_pyr()
         if isinstance(d_image, list):
             self.pyr_levels_dask = {1: d_image[0]}
+        else:
+            self.pyr_levels_dask = {1: d_image}
+
         self.base_layer_idx = 0
 
     def get_dask_pyr(self):
@@ -61,11 +64,18 @@ class TiffFileRegImage:
                 self.largest_series,
             )[0]
         else:
-            warnings.warn(
-                "Unable to parse pixel resolution information from file"
-                " defaulting to 1"
-            )
-            return 1.0
+            try:
+                return tifftag_xy_pixel_sizes(
+                    self.tf,
+                    self.largest_series,
+                    0,
+                )[0]
+            except KeyError:
+                warnings.warn(
+                    "Unable to parse pixel resolution information from file"
+                    " defaulting to 1"
+                )
+                return 1.0
 
     def _get_ch_names(self):
         if self.tf.ome_metadata:
@@ -101,3 +111,8 @@ class TiffFileRegImage:
             channel_idx = 0
         image = tf_zarr_read_single_ch(self.image_filepath, channel_idx, self.is_rgb)
         return image
+
+
+self = TiffFileRegImage(
+    "/Users/nhp/db/Dropbox (VU Basic Sciences)/benchmark/s04_bmark_mb_50um_AF_paq.tif"
+)

--- a/napari_imsmicrolink/data/tifffile_reader.py
+++ b/napari_imsmicrolink/data/tifffile_reader.py
@@ -111,8 +111,3 @@ class TiffFileRegImage:
             channel_idx = 0
         image = tf_zarr_read_single_ch(self.image_filepath, channel_idx, self.is_rgb)
         return image
-
-
-self = TiffFileRegImage(
-    "/Users/nhp/db/Dropbox (VU Basic Sciences)/benchmark/s04_bmark_mb_50um_AF_paq.tif"
-)

--- a/napari_imsmicrolink/data/tifffile_reader.py
+++ b/napari_imsmicrolink/data/tifffile_reader.py
@@ -1,0 +1,103 @@
+import warnings
+from pathlib import Path
+from tifffile import TiffFile
+from napari_imsmicrolink.utils.image import (
+    guess_rgb,
+    get_tifffile_info,
+    tf_zarr_read_single_ch,
+    tifffile_to_dask,
+)
+from ome_types import from_xml
+from napari_imsmicrolink.utils.tifffile_meta import (
+    tifftag_xy_pixel_sizes,
+    ometiff_xy_pixel_sizes,
+    svs_xy_pixel_sizes,
+    ometiff_ch_names,
+)
+
+TIFFFILE_EXTS = [".scn", ".ome.tiff", ".tif", ".tiff", ".svs", ".ndpi"]
+
+
+class TiffFileRegImage:
+    def __init__(self, image_fp):
+        self.image_filepath = image_fp
+        self.tf = TiffFile(self.image_filepath)
+        self.reader = "tifffile"
+
+        (self.im_dims, self.im_dtype, self.largest_series) = self._get_image_info()
+
+        self.im_dims = tuple(self.im_dims)
+        self.is_rgb = guess_rgb(self.im_dims)
+        self.n_ch = self.im_dims[2] if self.is_rgb else self.im_dims[0]
+
+        self.base_layer_pixel_res = self._get_im_res()
+        self.cnames = self._get_ch_names()
+        self.ccolors = None
+
+        d_image = self.get_dask_pyr()
+        if isinstance(d_image, list):
+            self.pyr_levels_dask = {1: d_image[0]}
+        self.base_layer_idx = 0
+
+    def get_dask_pyr(self):
+        return tifffile_to_dask(self.image_filepath, self.largest_series)
+
+    def _get_im_res(self):
+        if Path(self.image_filepath).suffix.lower() in [".scn", ".ndpi"]:
+            return tifftag_xy_pixel_sizes(
+                self.tf,
+                self.largest_series,
+                0,
+            )[0]
+        elif Path(self.image_filepath).suffix.lower() in [".svs"]:
+            return svs_xy_pixel_sizes(
+                self.tf,
+                self.largest_series,
+                0,
+            )[0]
+        elif self.tf.ome_metadata:
+            return ometiff_xy_pixel_sizes(
+                from_xml(self.tf.ome_metadata),
+                self.largest_series,
+            )[0]
+        else:
+            warnings.warn(
+                "Unable to parse pixel resolution information from file"
+                " defaulting to 1"
+            )
+            return 1.0
+
+    def _get_ch_names(self):
+        if self.tf.ome_metadata:
+            cnames = ometiff_ch_names(
+                from_xml(self.tf.ome_metadata), self.largest_series
+            )
+        else:
+            cnames = []
+            if self.is_rgb:
+                cnames.append("C01 - RGB")
+            else:
+                for idx, ch in enumerate(range(self.n_ch)):
+                    cnames.append(f"C{str(idx + 1).zfill(2)}")
+
+        return cnames
+
+    def _get_image_info(self):
+        if len(self.tf.series) > 1:
+            warnings.warn(
+                "The tiff contains multiple series, "
+                "the largest series will be read by default"
+            )
+
+        im_dims, im_dtype, largest_series = get_tifffile_info(self.image_filepath)
+
+        return im_dims, im_dtype, largest_series
+
+    def read_single_channel(self, channel_idx: int):
+        if channel_idx > (self.n_ch - 1):
+            warnings.warn(
+                "channel_idx exceeds number of channels, reading channel at channel_idx == 0"
+            )
+            channel_idx = 0
+        image = tf_zarr_read_single_ch(self.image_filepath, channel_idx, self.is_rgb)
+        return image

--- a/napari_imsmicrolink/utils/czi.py
+++ b/napari_imsmicrolink/utils/czi.py
@@ -8,6 +8,8 @@ import dask.array as da
 import zarr
 import cv2
 
+from napari_imsmicrolink.utils.image import compute_sub_res
+
 
 class CziRegImageReader(CziFile):
     """
@@ -326,23 +328,3 @@ def czi_tile_grayscale(rgb_image):
     )
 
     return np.expand_dims(result, axis=-1)
-
-
-def compute_sub_res(zarray, ds_factor, tile_size, is_rgb, im_dtype):
-    if is_rgb:
-        resampling_axis = {1: 2 ** ds_factor, 1: 2 ** ds_factor, 2: 1}
-        tiling = (tile_size, tile_size, 3)
-    else:
-        resampling_axis = {0: 1, 1: 2 ** ds_factor, 2: 2 ** ds_factor}
-        tiling = (1, tile_size, tile_size)
-
-    resampled_zarray_subres = da.coarsen(
-        np.mean,
-        zarray,
-        resampling_axis,
-        trim_excess=True,
-    )
-    resampled_zarray_subres = resampled_zarray_subres.astype(im_dtype)
-    resampled_zarray_subres = resampled_zarray_subres.rechunk(tiling)
-
-    return resampled_zarray_subres

--- a/napari_imsmicrolink/utils/image.py
+++ b/napari_imsmicrolink/utils/image.py
@@ -1,5 +1,20 @@
 from typing import Tuple, List
+from pathlib import Path
 import numpy as np
+import zarr
+import dask.array as da
+import SimpleITK as sitk
+from dask import array as da
+from tifffile import TiffFile, imread, xml2dict
+
+
+def tifffile_to_dask(im_fp: [str, Path], largest_series: int):
+    imdata = zarr.open(imread(im_fp, aszarr=True, series=largest_series))
+    if isinstance(imdata, zarr.hierarchy.Group):
+        imdata = [da.from_zarr(imdata[z]) for z in imdata.array_keys()]
+    else:
+        imdata = da.from_zarr(imdata)
+    return imdata
 
 
 def calc_pyramid_levels(
@@ -111,3 +126,276 @@ def guess_rgb(shape: Tuple[int, ...]) -> bool:
         rgb = False
 
     return rgb
+
+
+def tf_get_largest_series(image_filepath):
+    """
+    Determine largest series for .scn files by examining metadata
+    For other multi-series files, find the one with the most pixels
+
+    Parameters
+    ----------
+    image_filepath: str
+        path to the image file
+
+    Returns
+    -------
+    largest_series:int
+        index of the largest series in the image data
+    """
+    fp_ext = Path(image_filepath).suffix.lower()
+    tf_im = TiffFile(image_filepath)
+    if fp_ext == ".scn":
+        scn_meta = xml2dict(tf_im.scn_metadata)
+        image_meta = scn_meta.get("scn").get("collection").get("image")
+        largest_series = np.argmax(
+            [
+                im.get("scanSettings").get("objectiveSettings").get("objective")
+                for im in image_meta
+            ]
+        )
+    else:
+        largest_series = np.argmax(
+            [
+                np.prod(np.asarray(series.shape), dtype=np.int64)
+                for series in tf_im.series
+            ]
+        )
+    return largest_series
+
+
+def tifffile_zarr_backend(
+    image_filepath, largest_series, preprocessing, force_rgb=None
+):
+    """
+    Read image with tifffile and use zarr to read data into memory
+
+    Parameters
+    ----------
+    image_filepath: str
+        path to the image file
+    largest_series: int
+        index of the largest series in the image
+    preprocessing:
+        whether to do some read-time pre-processing
+        - greyscale conversion (at the tile level)
+        - read individual or range of channels (at the tile level)
+
+    Returns
+    -------
+    image: sitk.Image
+        image ready for other registration pre-processing
+
+    """
+    print("using zarr backend")
+    zarr_series = imread(image_filepath, aszarr=True, series=largest_series)
+    zarr_store = zarr.open(zarr_series)
+    zarr_im = zarr_get_base_pyr_layer(zarr_store)
+    return read_preprocess_array(
+        zarr_im, preprocessing=preprocessing, force_rgb=force_rgb
+    )
+
+
+def tifffile_dask_backend(
+    image_filepath, largest_series, preprocessing, force_rgb=None
+):
+    """
+    Read image with tifffile and use dask to read data into memory
+
+    Parameters
+    ----------
+    image_filepath: str
+        path to the image file
+    largest_series: int
+        index of the largest series in the image
+    preprocessing:
+        whether to do some read-time pre-processing
+        - greyscale conversion (at the tile level)
+        - read individual or range of channels (at the tile level)
+
+    Returns
+    -------
+    image: sitk.Image
+        image ready for other registration pre-processing
+
+    """
+    print("using dask backend")
+    zarr_series = imread(image_filepath, aszarr=True, series=largest_series)
+    zarr_store = zarr.open(zarr_series)
+    dask_im = da.squeeze(da.from_zarr(zarr_get_base_pyr_layer(zarr_store)))
+    return read_preprocess_array(
+        dask_im, preprocessing=preprocessing, force_rgb=force_rgb
+    )
+
+
+def zarr_get_base_pyr_layer(zarr_store):
+    """
+    Find the base pyramid layer of a zarr store
+
+    Parameters
+    ----------
+    zarr_store
+        zarr store
+
+    Returns
+    -------
+    zarr_im: zarr.core.Array
+        zarr array of base layer
+    """
+    if isinstance(zarr_store, zarr.hierarchy.Group):
+        zarr_im = zarr_store[str(0)]
+    elif isinstance(zarr_store, zarr.core.Array):
+        zarr_im = zarr_store
+    return zarr_im
+
+
+def ensure_dask_array(image):
+    if isinstance(image, da.core.Array):
+        return image
+
+    if isinstance(image, zarr.Array):
+        return da.from_zarr(image)
+
+    # handles np.ndarray _and_ other array like objects.
+    return da.from_array(image)
+
+
+def read_preprocess_array(array, preprocessing, force_rgb=None):
+    """Read np.array, zarr.Array, or dask.array image into memory
+    with preprocessing for registration."""
+    is_interleaved = guess_rgb(array.shape)
+    is_rgb = is_interleaved if not force_rgb else force_rgb
+
+    if is_rgb:
+        if preprocessing:
+            image_out = np.asarray(grayscale(array, is_interleaved=is_interleaved))
+            image_out = sitk.GetImageFromArray(image_out)
+        else:
+            image_out = np.asarray(array)
+            if not is_interleaved:
+                image_out = np.rollaxis(image_out, 0, 3)
+            image_out = sitk.GetImageFromArray(image_out, isVector=True)
+
+    elif len(array.shape) == 2:
+        image_out = sitk.GetImageFromArray(np.asarray(array))
+
+    else:
+        if preprocessing:
+            if preprocessing.ch_indices and len(array.shape) > 2:
+                chs = list(preprocessing.ch_indices)
+                array = array[chs, :, :]
+
+        image_out = sitk.GetImageFromArray(np.squeeze(np.asarray(array)))
+
+    return image_out
+
+
+def get_tifffile_info(image_filepath):
+    largest_series = tf_get_largest_series(image_filepath)
+    zarr_im = zarr.open(imread(image_filepath, aszarr=True, series=largest_series))
+    zarr_im = zarr_get_base_pyr_layer(zarr_im)
+    im_dims = np.squeeze(zarr_im.shape)
+    if len(im_dims) == 2:
+        im_dims = np.concatenate([[1], im_dims])
+    im_dtype = zarr_im.dtype
+
+    return im_dims, im_dtype, largest_series
+
+
+def grayscale(rgb_image, is_interleaved=False):
+    """
+    convert RGB image data to greyscale
+
+    Parameters
+    ----------
+    rgb_image: np.ndarray
+        image data
+    Returns
+    -------
+    image:np.ndarray
+        returns 8-bit greyscale image for 24-bit RGB image
+    """
+    if is_interleaved is True:
+        result = (
+            (rgb_image[..., 0] * 0.2125).astype(np.uint8)
+            + (rgb_image[..., 1] * 0.7154).astype(np.uint8)
+            + (rgb_image[..., 2] * 0.0721).astype(np.uint8)
+        )
+    else:
+        result = (
+            (rgb_image[0, ...] * 0.2125).astype(np.uint8)
+            + (rgb_image[1, ...] * 0.7154).astype(np.uint8)
+            + (rgb_image[2, ...] * 0.0721).astype(np.uint8)
+        )
+
+    return result
+
+
+def tf_zarr_read_single_ch(
+    image_filepath, channel_idx, is_rgb, is_rgb_interleaved=True
+):
+    """
+    Reads a single channel using zarr or dask in combination with tifffile
+
+    Parameters
+    ----------
+    image_filepath:str
+        file path to image
+    channel_idx:int
+        index of the channel to be read
+    is_rgb:bool
+        whether image is rgb interleaved
+
+    Returns
+    -------
+    im:np.ndarray
+        image as a np.ndarray
+    """
+    largest_series = tf_get_largest_series(image_filepath)
+    zarr_im = zarr.open(imread(image_filepath, aszarr=True, series=largest_series))
+    zarr_im = zarr_get_base_pyr_layer(zarr_im)
+    try:
+        im = da.squeeze(da.from_zarr(zarr_im))
+        if is_rgb and is_rgb_interleaved is True:
+            im = im[:, :, channel_idx].compute()
+        elif len(im.shape) > 2:
+            im = im[channel_idx, :, :].compute()
+        else:
+            im = im.compute()
+
+    except ValueError:
+        im = zarr_im
+        if is_rgb is True and is_rgb_interleaved is True:
+            im = im[:, :, channel_idx]
+        elif len(im.shape) > 2:
+            im = im[channel_idx, :, :].compute()
+        else:
+            im = im.compute()
+    return im
+
+
+def yield_tiles(z, tile_size, is_rgb):
+    for y in range(0, z.shape[0], tile_size):
+        for x in range(0, z.shape[1], tile_size):
+            if is_rgb:
+                yield z[y : y + tile_size, x : x + tile_size, :].compute()
+
+
+def compute_sub_res(zarray, ds_factor, tile_size, is_rgb, im_dtype):
+    if is_rgb:
+        resampling_axis = {0: 2 ** ds_factor, 1: 2 ** ds_factor, 2: 1}
+        tiling = (tile_size, tile_size, 3)
+    else:
+        resampling_axis = {0: 1, 1: 2 ** ds_factor, 2: 2 ** ds_factor}
+        tiling = (1, tile_size, tile_size)
+
+    resampled_zarray_subres = da.coarsen(
+        np.mean,
+        zarray,
+        resampling_axis,
+        trim_excess=True,
+    )
+    resampled_zarray_subres = resampled_zarray_subres.astype(im_dtype)
+    resampled_zarray_subres = resampled_zarray_subres.rechunk(tiling)
+
+    return resampled_zarray_subres

--- a/napari_imsmicrolink/utils/ome.py
+++ b/napari_imsmicrolink/utils/ome.py
@@ -35,9 +35,8 @@ def generate_ome(image_name, pixel_metadata: dict, channel_meta_list: list):
         )
     )
 
-    if not pixel_metadata.get("Interleaved"):
-        for idx, ch in enumerate(channel_meta_list):
-            ch.update({"id": f"Channel:{idx}"})
-            ome.images[0].pixels.channels.append(Channel(**ch))
+    for idx, ch in enumerate(channel_meta_list):
+        ch.update({"id": f"Channel:{idx}"})
+        ome.images[0].pixels.channels.append(Channel(**ch))
 
     return ome

--- a/napari_imsmicrolink/utils/tifffile_meta.py
+++ b/napari_imsmicrolink/utils/tifffile_meta.py
@@ -1,0 +1,86 @@
+from typing import Tuple
+from tifffile import TiffFile
+from ome_types.model import OME
+from pint import UnitRegistry
+
+
+def tifftag_xy_pixel_sizes(
+    rdr: TiffFile, series_idx: int, level_idx: int
+) -> Tuple[float, ...]:
+    """Resolution data is stored in the TIFF tags in
+    Pixels per cm, this is converted to microns per pixel
+    """
+    # pages are accessed because they contain the tiff tag
+    # subset by series -> level -> first page contains all tags
+    current_page = rdr.series[series_idx].levels[level_idx].pages[0]
+
+    x_res = current_page.tags["XResolution"].value
+    y_res = current_page.tags["XResolution"].value
+
+    res_unit = current_page.tags["ResolutionUnit"].value
+
+    # convert units to micron
+    # res_unit == 1: undefined (px)
+    # res_unit == 2 pixels per inch
+    # res unit == 3 pixels per cm
+    # in all cases we convert to um
+    # https://www.awaresystems.be/imaging/tiff/tifftags/resolutionunit.html
+    if res_unit.value == 1:
+        res_to_um = 1
+    if res_unit.value == 2:
+        res_to_um = 25400
+    elif res_unit.value == 3:
+        res_to_um = 10000
+
+    # conversion of pixels / um to um / pixel
+    x_res_um = (1 / (x_res[0] / x_res[1])) * res_to_um
+    y_res_um = (1 / (y_res[0] / y_res[1])) * res_to_um
+
+    return (x_res_um, y_res_um)
+
+
+def svs_xy_pixel_sizes(
+    rdr: TiffFile, series_idx: int, level_idx: int
+) -> Tuple[float, ...]:
+    """Get resolution data stored in ImageDescription of SVS"""
+    # pages are accessed because they contain the tiff tag
+    # subset by series -> level -> first page contains all tags
+    current_page = rdr.series[series_idx].levels[level_idx].pages[0]
+    id_str = current_page.tags["ImageDescription"].value
+    svs_info = id_str.split("|")
+    mpp_val = None
+    for i in svs_info:
+        if "MPP" in i:
+            mpp_val = float(i.split("=")[1])
+
+    if mpp_val:
+        return (mpp_val, mpp_val)
+    else:
+        return (1.0, 1.0)
+
+
+def ometiff_xy_pixel_sizes(ome_metadata: OME, series_idx: int):
+    ps_x = ome_metadata.images[series_idx].pixels.physical_size_x
+    ps_y = ome_metadata.images[series_idx].pixels.physical_size_y
+    ps_unit = ome_metadata.images[series_idx].pixels.physical_size_x_unit
+
+    if ps_unit.name.lower() != "micrometer":
+        ureg = UnitRegistry()
+        cur_size = ps_x * ureg(ps_unit.name.lower())
+        out_um = cur_size.to("micrometer")
+        ps_x_out = out_um.magnitude
+        return (ps_x_out, ps_x_out)
+    else:
+        return (ps_x, ps_y)
+
+
+def ometiff_ch_names(ome_metadata: OME, series_idx: int):
+    ch_meta = ome_metadata.images[series_idx].pixels.channels
+    cnames = []
+    for idx, ch in enumerate(ch_meta):
+        if ch.name:
+            cnames.append(ch.name)
+        else:
+            cnames.append(f"C{str(idx + 1).zfill(2)}")
+
+    return cnames

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 
 numpy
 dask
+zarr
 qtpy
 aicsimageio[bioformats]
 bioformats_jar

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,13 +35,16 @@ install_requires =
     napari-plugin-engine>=0.1.4
     numpy
     dask
+    zarr
     qtpy
     aicsimageio[all]
     bioformats_jar
     SimpleITK
+    pandas
     h5py
     opencv-python
-    lxml
+    czifile
+    imagecodecs
 
 
 [options.entry_points] 


### PR DESCRIPTION
Closes #20.

Adds a reader with the `tifffile` backend. Tries to create an dask image pyramid, if possible for more rapid visualization.

Fixes various bugs in transformation control.

Also adds RGB support for reading and writing. 